### PR TITLE
Fix Entries with (inline) does not parse well

### DIFF
--- a/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
+++ b/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
@@ -231,7 +231,7 @@ PerfTreeParserTest >> setUp [
                |          
                 --45.91%--do_syscall_64
                           |          
-                          |--36.78%--__x64_sys_read
+                          |--36.78%--__x64_sys_read (inlined)
                           |
                           |          
                           |--6.88%--syscall_exit_to_user_mode
@@ -372,7 +372,9 @@ PerfTreeParserTest >> testNameOf [
 		assert: (testParserSamePercentage nameOf: 4)
 		equals: '__x64_sys_read'.
 
-	self assert: (testParserSamePercentage nameOf: 6) equals: 'vfs_read'
+	self assert: (testParserSamePercentage nameOf: 6) equals: 'vfs_read'.
+	
+	self assert: (testParserMultipleChildren nameOf: 4) equals: '__x64_sys_read (inlined)'.
 ]
 
 { #category : 'tests' }
@@ -387,7 +389,7 @@ PerfTreeParserTest >> testNodes [
 	| example |
 	example := testNodeMultipleChildren firstChild firstChild children.
 
-	self assert: example first name equals: '__x64_sys_read'.
+	self assert: example first name equals: '__x64_sys_read (inlined)'.
 
 	self assert: example second name equals: 'syscall_exit_to_user_mode'.
 
@@ -502,7 +504,7 @@ PerfTreeParserTest >> testTraces [
 
 	self assert: multipleTraces size equals: 3.
 
-	self assert: multipleTraces first name equals: '__x64_sys_read'.
+	self assert: multipleTraces first name equals: '__x64_sys_read (inlined)'.
 
 	self assert: multipleTraces last name equals: 'do_sys_openat2'.
 

--- a/src/PerfTreeParser/PerfTreeParser.class.st
+++ b/src/PerfTreeParser/PerfTreeParser.class.st
@@ -105,9 +105,12 @@ PerfTreeParser >> lastSpaceAt: aLine [
 	line := self readLine: aLine.
 	lastSpace := 0.
 
-	1 to: line size do: [ :i |
-		((line at: i) = Character space or: [ (line at: i) = $- ]) ifTrue: [
-			lastSpace := i ] ].
+	2 to: line size do: [ :i |
+		(((line at: i) = Character space and: [
+			  (line at: i - 1) = Character space ]) or: [
+			 (line at: i) = $- or: [
+				 (line at: i) = Character space and: [ (line at: i - 1) = $] ] ] ])
+			ifTrue: [ lastSpace := i ] ].
 	^ lastSpace
 ]
 
@@ -168,7 +171,7 @@ PerfTreeParser >> percentageOf: aLine [
 	stringLine := ((((self readLine: aLine) copyUpTo: $%) last: 5)
 		              copyWithout: $-) copyWithout: Character space.
 
-	stringLine = ((self readLine: aLine) last: 5) ifTrue: [
+	stringLine = ((self readLine: aLine) last: stringLine size) ifTrue: [
 		^ self percentageOf: aLine - 1 ].
 
 	numbers := stringLine asNumber.


### PR DESCRIPTION
- Fix #6 
- Modified tests to prevent this issue from happening in the future
- Also changed `percentageOf` to be able to read strings smaller than 5 characters when comparing to the content of the line