### PR TITLE
Fix "Wrong percentages on nodes"

### DIFF
--- a/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
+++ b/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
@@ -482,9 +482,45 @@ PerfTreeParserTest >> testRealPercentageOf [
 { #category : 'tests' }
 PerfTreeParserTest >> testTime [
 	
+	| example |
+	example := testNodeMultipleChildren firstChild firstChild.
+	
+	self assert: example time equals: 6.84.
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testTimeOf [
+
+	self
+		assert:
+		(testParserSimple timeOf: testParserSimple numberOfFunctions)
+		equals: 146.24.
+
+	self assert: (testParserSimple timeOf: 3) equals: 36.31
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testTimeWithChildrenOf [
+	
+	self
+		assert:
+		(testParserSimple timeWithChildrenOf:
+			 testParserSimple numberOfFunctions)
+		equals:
+		(testParserSimple timeOf: testParserSimple numberOfFunctions).
+	
+	self assert: (testParserMultipleChildren timeWithChildrenOf: 3) equals: 182.54.
+	
+	self assert: (testParserSamePercentage timeWithChildrenOf: 5) equals: 146.24.
+	
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testTotalTime [
+	
 	self assert: testParserSimple time equals: 397.592.
 	
-	self assert: testParserSimple root time equals: 397.592.
+	self assert: testParserSimple root totalTime equals: 397.592.
 ]
 
 { #category : 'tests' }
@@ -498,7 +534,7 @@ PerfTreeParserTest >> testTraces [
 
 	self assert: traces first name equals: '__x64_sys_read'.
 
-	self assert: traces first weight equals: 146.24.
+	self assert: traces first time equals: 146.24.
 
 	self assert: multipleTraces size equals: 3.
 
@@ -506,27 +542,7 @@ PerfTreeParserTest >> testTraces [
 
 	self assert: multipleTraces last name equals: 'do_sys_openat2'.
 
-	self assert: multipleTraces last weight equals: 2.11
-]
-
-{ #category : 'tests' }
-PerfTreeParserTest >> testWeight [
-	
-	| example |
-	example := testNodeMultipleChildren firstChild firstChild.
-	
-	self assert: example weight equals: 6.84.
-]
-
-{ #category : 'tests' }
-PerfTreeParserTest >> testWeightOf [
-
-	self
-		assert:
-		(testParserSimple weightOf: testParserSimple numberOfFunctions)
-		equals: 146.24.
-
-	self assert: (testParserSimple weightOf: 3) equals: 36.31
+	self assert: multipleTraces last time equals: 2.11
 ]
 
 { #category : 'tests' }

--- a/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
+++ b/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
@@ -338,6 +338,21 @@ PerfTreeParserTest >> testFindChildrenOfRecursive [
 ]
 
 { #category : 'tests' }
+PerfTreeParserTest >> testHardestCall [
+
+	| multipleChildrenTree multipleChildrenTraces samePercentageTraces samePercentageTree |
+	multipleChildrenTraces := testNodeMultipleChildren traces.
+	multipleChildrenTree := PerfTreeTree new traces: multipleChildrenTraces.
+	
+	samePercentageTraces := testNodeSamePercentage traces.
+	samePercentageTree := PerfTreeTree new traces: samePercentageTraces.
+	
+	self assert: multipleChildrenTree hardestCall name equals: '__x64_sys_read'.
+	
+	self assert: samePercentageTree hardestCall name equals: 'ext4_file_read_iter'
+]
+
+{ #category : 'tests' }
 PerfTreeParserTest >> testIsLeaf [
 
 	| example |
@@ -543,6 +558,21 @@ PerfTreeParserTest >> testTraces [
 	self assert: multipleTraces last name equals: 'do_sys_openat2'.
 
 	self assert: multipleTraces last time equals: 2.11
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testTreeTotalTime [
+	
+	| multipleChildrenTree multipleChildrenTraces samePercentageTraces samePercentageTree |
+	multipleChildrenTraces := testNodeMultipleChildren traces.
+	multipleChildrenTree := PerfTreeTree new traces: multipleChildrenTraces.
+	
+	samePercentageTraces := testNodeSamePercentage traces.
+	samePercentageTree := PerfTreeTree new traces: samePercentageTraces.
+	
+	self assert: multipleChildrenTree totalTime equals: 175.63.
+	
+	self assert: samePercentageTree totalTime equals: 144.97
 ]
 
 { #category : 'tests' }

--- a/src/PerfTreeParser/PerfTreeNode.class.st
+++ b/src/PerfTreeParser/PerfTreeNode.class.st
@@ -52,7 +52,7 @@ PerfTreeNode >> isLeaf [
 PerfTreeNode >> isNotAlreadyLeafIn: leaves [
 
 	(leaves anySatisfy: [ :leaf |
-		 leaf name = self name and: [ leaf weight = self weight ] ])
+		 leaf name = self name and: [ leaf time = self time ] ])
 		ifTrue: [ ^ false ]
 		ifFalse: [ ^ true ]
 ]

--- a/src/PerfTreeParser/PerfTreeNode.class.st
+++ b/src/PerfTreeParser/PerfTreeNode.class.st
@@ -3,10 +3,11 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'name',
-		'weight',
 		'children',
 		'parent',
-		'totalTime'
+		'totalTime',
+		'time',
+		'timeWithChildren'
 	],
 	#category : 'PerfTreeParser',
 	#package : 'PerfTreeParser'
@@ -89,11 +90,35 @@ PerfTreeNode >> parent: aTreeNode [
 { #category : 'accessing' }
 PerfTreeNode >> time [
 
-	^ totalTime
+	^ time
 ]
 
 { #category : 'accessing' }
 PerfTreeNode >> time: aFloat [
+
+	time := aFloat
+]
+
+{ #category : 'accessing' }
+PerfTreeNode >> timeWithChildren [
+
+	^ timeWithChildren
+]
+
+{ #category : 'accessing' }
+PerfTreeNode >> timeWithChildren: anObject [
+
+	timeWithChildren := anObject
+]
+
+{ #category : 'accessing' }
+PerfTreeNode >> totalTime [
+
+	^ totalTime
+]
+
+{ #category : 'accessing' }
+PerfTreeNode >> totalTime: aFloat [
 
 	totalTime := aFloat
 ]
@@ -108,18 +133,6 @@ PerfTreeNode >> traces [
 	^ leaves collect: [ :l |
 		  PerfTreeTrace new
 			  name: l name;
-			  weight: l weight;
+			  time: l time;
 			  yourself ]
-]
-
-{ #category : 'accessing' }
-PerfTreeNode >> weight [
-
-	^ weight
-]
-
-{ #category : 'accessing' }
-PerfTreeNode >> weight: aFloat [
-
-	weight := aFloat
 ]

--- a/src/PerfTreeParser/PerfTreeParser.class.st
+++ b/src/PerfTreeParser/PerfTreeParser.class.st
@@ -119,8 +119,9 @@ PerfTreeParser >> nodeAtIndex: aNodeIndex [
 	| node |
 	node := PerfTreeNode new
 		         name: (self nameOf: aNodeIndex);
-		         weight: (self weightOf: aNodeIndex);
-		         time: self time;
+		         time: (self timeOf: aNodeIndex);
+		         totalTime: self time;
+					timeWithChildren: (self timeWithChildrenOf: aNodeIndex);
 		         yourself.
 	node children: (self findChildrenOfIndex: aNodeIndex).
 	node children do: [ :grandchild | grandchild parent: node ].
@@ -210,10 +211,19 @@ PerfTreeParser >> time: aFloat [
 ]
 
 { #category : 'accessing' }
-PerfTreeParser >> weightOf: aNodeIndex [
+PerfTreeParser >> timeOf: aNodeIndex [
 
 	| newPercentage |
 	newPercentage := self realPercentageOf: aNodeIndex.
+
+	^ totalTime * (newPercentage/100) roundUpTo: 0.01
+]
+
+{ #category : 'accessing' }
+PerfTreeParser >> timeWithChildrenOf: aNodeIndex [
+
+	| newPercentage |
+	newPercentage := self percentageOf: aNodeIndex.
 
 	^ totalTime * (newPercentage/100) roundUpTo: 0.01
 ]

--- a/src/PerfTreeParser/PerfTreeTrace.class.st
+++ b/src/PerfTreeParser/PerfTreeTrace.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'name',
-		'weight'
+		'time'
 	],
 	#category : 'PerfTreeParser',
 	#package : 'PerfTreeParser'
@@ -22,13 +22,13 @@ PerfTreeTrace >> name: aName [
 ]
 
 { #category : 'accessing' }
-PerfTreeTrace >> weight [
+PerfTreeTrace >> time [
 
-	^ weight
+	^ time
 ]
 
 { #category : 'accessing' }
-PerfTreeTrace >> weight: aFloat [
+PerfTreeTrace >> time: anObject [
 
-	weight := aFloat
+	time := anObject
 ]

--- a/src/PerfTreeParser/PerfTreeTree.class.st
+++ b/src/PerfTreeParser/PerfTreeTree.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : 'PerfTreeTree',
+	#superclass : 'Object',
+	#instVars : [
+		'traces'
+	],
+	#category : 'PerfTreeParser',
+	#package : 'PerfTreeParser'
+}
+
+{ #category : 'accessing' }
+PerfTreeTree >> hardestCall [
+
+	| hardest |
+	traces ifEmpty: [ ^ nil ] ifNotEmpty: [ hardest := traces first ].
+	traces do: [:trace | trace time > hardest time ifTrue: [ hardest := trace ] ].
+	^ hardest
+]
+
+{ #category : 'accessing' }
+PerfTreeTree >> totalTime [
+
+	^ traces sum: [:trace | trace time ]
+]
+
+{ #category : 'accessing' }
+PerfTreeTree >> traces [
+
+	^ traces
+]
+
+{ #category : 'accessing' }
+PerfTreeTree >> traces: aCollectionOfTraces [
+
+	traces := aCollectionOfTraces
+]


### PR DESCRIPTION
- Fix #7
- Renamed `weight` to `time`
- Added `timeWithChildren`
- Added `PerfTreeTree` class
- Added `hardestCall` and `totalTime` to it with their tests