### PR TITLE
Fix out of bounds bug

### DIFF
--- a/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
+++ b/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
@@ -164,7 +164,8 @@ PerfTreeParserTest >> setUp [
                           |          |          
                           |           --36.46%--ext4_file_read_iter
                           |                     |          
-'].
+     0.00%     0.00%  sh               [kernel.kallsyms]           [k] ghes_notify_nmi
+     0.00%     0.00%  sh               [kernel.kallsyms]           [k] nmi_cpu_backtrace'].
 
 	memoryFS / ('perf_stock_multiple_children.txt') writeStreamDo: [:stream | stream nextPutAll: '# ========
 # captured on    : Wed May 29 09:28:58 2024
@@ -347,7 +348,7 @@ PerfTreeParserTest >> testHardestCall [
 	samePercentageTraces := testNodeSamePercentage traces.
 	samePercentageTree := PerfTreeTree new traces: samePercentageTraces.
 	
-	self assert: multipleChildrenTree hardestCall name equals: '__x64_sys_read'.
+	self assert: multipleChildrenTree hardestCall name equals: '__x64_sys_read (inlined)'.
 	
 	self assert: samePercentageTree hardestCall name equals: 'ext4_file_read_iter'
 ]
@@ -494,6 +495,19 @@ PerfTreeParserTest >> testRealPercentageOf [
 	self
 		assert: (testParserSamePercentage realPercentageOf: 4)
 		equals: 0.0
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testSmallTrees [
+
+	| lastTree beforeTheLastTree |
+	lastTree := (PerfTreeParser parseFile: fileSamePercentage) last.
+	beforeTheLastTree := (PerfTreeParser parseFile: fileSamePercentage) second.
+	
+	self assert: beforeTheLastTree children isEmpty.
+	self assert: lastTree children isEmpty.
+
+	
 ]
 
 { #category : 'tests' }

--- a/src/PerfTreeParser/PerfTreeParser.class.st
+++ b/src/PerfTreeParser/PerfTreeParser.class.st
@@ -70,10 +70,14 @@ PerfTreeParser >> findChildrenIndexOfIndex: aNodeIndex [
 	lastNodeIndex := self numberOfFunctions.
 	everyChildren := OrderedCollection new.
 
-	(self percentageOf: aNodeIndex) = (self percentageOf: aNodeIndex + 1)
-		ifTrue: [
-			everyChildren add: aNodeIndex + 1.
-			^ everyChildren ].
+	(aNodeIndex + 1 between: 1 and: self numberOfFunctions) ifFalse: [
+		^ everyChildren ].
+
+	((self percentageOf: aNodeIndex)
+	 = (self percentageOf: aNodeIndex + 1) and: [
+		 ((self readLine: aNodeIndex + 1) findString: '[') = 0 ]) ifTrue: [
+		everyChildren add: aNodeIndex + 1.
+		^ everyChildren ].
 
 	newBranch := false.
 	nodeSpaces := self numberOfSpacesAt: aNodeIndex.


### PR DESCRIPTION
Fix #5, now if the `NodeIndex + 1` is out of bounds, the parent has no child 
Fix another issue I found where one line trees had the function below as child even though they are not related
```
     0.00%     0.00%  sh               [kernel.kallsyms]           [k] ghes_notify_nmi
     0.00%     0.00%  sh               [kernel.kallsyms]           [k] nmi_cpu_backtrace
```
For example, in this case `nmi_cpu_backtrace` would have been considered as the child of `ghes_notify_nmi` but they clearly are not (at least in this case) related