### PR TITLE
Get precise data

### DIFF
--- a/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
+++ b/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
@@ -270,7 +270,6 @@ PerfTreeParserTest >> tearDown [
 
 { #category : 'tests' }
 PerfTreeParserTest >> testDifferenceOfSpacesAt [
-	"Classical case"
 
 	self
 		assert: (testParserSamePercentage differenceOfSpacesAt: 6)
@@ -286,25 +285,37 @@ PerfTreeParserTest >> testDifferenceOfSpacesAt [
 
 { #category : 'tests' }
 PerfTreeParserTest >> testFindChildrenIndexOfIndex [
-	"The last has no children"
-
-	self assert: (testParserSimple findChildrenIndexOfIndex:
-			 testParserSimple numberOfFunctions) isEmpty.
-
-	"Case where 2 functions have the same number of spaces."
-	self
-		assert: (testParserSimple findChildrenIndexOfIndex: 3)
-		equals: { 4 } asOrderedCollection.
-
 	"Classical case"
+
 	self
 		assert: (testParserSamePercentage findChildrenIndexOfIndex: 5)
-		equals: { 6 } asOrderedCollection.
+		equals: { 6 } asOrderedCollection
+]
 
+{ #category : 'tests' }
+PerfTreeParserTest >> testFindChildrenIndexOfIndexWithMutltipleChildren [
 	"Multiple children"
+
 	self
 		assert: (testParserMultipleChildren findChildrenIndexOfIndex: 3)
 		equals: { 4. 5. 8 } asOrderedCollection
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testFindChildrenIndexOfIndexWithNoChildren [
+	"The last has no children"
+
+	self assert: (testParserSimple findChildrenIndexOfIndex:
+			 testParserSimple numberOfFunctions) isEmpty
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testFindChildrenIndexOfIndexWithSameNumberOfSpaces [
+	"Case where 2 functions have the same number of spaces."
+
+	self
+		assert: (testParserSimple findChildrenIndexOfIndex: 3)
+		equals: { 4 } asOrderedCollection
 ]
 
 { #category : 'tests' }
@@ -358,12 +369,21 @@ PerfTreeParserTest >> testIsLeaf [
 
 	| example |
 	example := testNodeSimple firstChild firstChild.
-	
+
 	self assert: example isLeaf not.
+
+	self assert: example children first isLeaf
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testIsNotLeaf [
+
+	| example |
+	example := testNodeSimple firstChild firstChild.
+
 	self assert: example isNotLeaf.
-	
-	self assert: example children first isLeaf.
-	self assert: example children first isNotLeaf not.
+
+	self assert: example children first isNotLeaf not
 ]
 
 { #category : 'tests' }
@@ -451,14 +471,22 @@ PerfTreeParserTest >> testPercentageOf [
 	self
 		assert:
 		(testParserSimple percentageOf: testParserSimple numberOfFunctions)
-		equals: 36.78.
+		equals: 36.78
+]
 
+{ #category : 'tests' }
+PerfTreeParserTest >> testPercentageOfWith3Digits [
 	"Case with 3 digits."
+
 	self
 		assert: (testParserMultipleChildren percentageOf: 8)
-		equals: 0.53.
+		equals: 0.53
+]
 
+{ #category : 'tests' }
+PerfTreeParserTest >> testPercentageOfWithSamePercentage [
 	"Case with same percentage"
+
 	self
 		assert: (testParserSamePercentage percentageOf: 4)
 		equals: (testParserSamePercentage percentageOf: 5).
@@ -484,16 +512,25 @@ PerfTreeParserTest >> testRawPercentageOf [
 			 testParserSimple numberOfFunctions)
 		equals: testNodeSimple traces first rawPercentage.
 
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testRawPercentageOfWith3Digits [
 	"Case with 3 digits."
+
 	self
 		assert: (testParserMultipleChildren rawPercentageOf: 8)
 		equals: '0.53'.
 
 	self
 		assert: testNodeMultipleChildren traces last rawPercentage
-		equals: (testParserMultipleChildren rawPercentageOf: 8).
+		equals: (testParserMultipleChildren rawPercentageOf: 8)
+]
 
+{ #category : 'tests' }
+PerfTreeParserTest >> testRawPercentageOfWithSamePercentage [
 	"Case with same percentage"
+
 	self
 		assert: (testParserSamePercentage rawPercentageOf: 4)
 		equals: (testParserSamePercentage rawPercentageOf: 5).
@@ -596,17 +633,36 @@ PerfTreeParserTest >> testTraces [
 	traces := (PerfTreeParser findTraces: fileSimple) first.
 	multipleTraces := testNodeMultipleChildren traces.
 
-	self assert: traces size equals: 1.
-
 	self assert: traces first name equals: '__x64_sys_read'.
 
-	self assert: traces first time equals: 146.24.
+	self
+		assert: multipleTraces first name
+		equals: '__x64_sys_read (inlined)'.
+
+	self assert: multipleTraces last name equals: 'do_sys_openat2'
+]
+
+{ #category : 'tests' }
+PerfTreeParserTest >> testTracesNumber [
+
+	| traces multipleTraces |
+	traces := (PerfTreeParser findTraces: fileSimple) first.
+	multipleTraces := testNodeMultipleChildren traces.
+
+	self assert: traces size equals: 1.
 
 	self assert: multipleTraces size equals: 3.
 
-	self assert: multipleTraces first name equals: '__x64_sys_read (inlined)'.
+]
 
-	self assert: multipleTraces last name equals: 'do_sys_openat2'.
+{ #category : 'tests' }
+PerfTreeParserTest >> testTracesTime [
+
+	| traces multipleTraces |
+	traces := (PerfTreeParser findTraces: fileSimple) first.
+	multipleTraces := testNodeMultipleChildren traces.
+
+	self assert: traces first time equals: 146.24.
 
 	self assert: multipleTraces last time equals: 2.11
 ]

--- a/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
+++ b/src/PerfTreeParser-Tests/PerfTreeParserTest.class.st
@@ -468,6 +468,41 @@ PerfTreeParserTest >> testPercentageOf [
 ]
 
 { #category : 'tests' }
+PerfTreeParserTest >> testRawPercentageOf [
+	"Cases with 4 digits."
+
+	self assert: (testParserSimple rawPercentageOf: 1) equals: '46.02'.
+
+	self
+		assert: testNodeSimple rawPercentage
+		equals: (testParserSimple rawPercentageOf: 1).
+
+	self
+		assert:
+		(testParserSimple rawPercentageOf:
+			 testParserSimple numberOfFunctions)
+		equals: testNodeSimple traces first rawPercentage.
+
+	"Case with 3 digits."
+	self
+		assert: (testParserMultipleChildren rawPercentageOf: 8)
+		equals: '0.53'.
+
+	self
+		assert: testNodeMultipleChildren traces last rawPercentage
+		equals: (testParserMultipleChildren rawPercentageOf: 8).
+
+	"Case with same percentage"
+	self
+		assert: (testParserSamePercentage rawPercentageOf: 4)
+		equals: (testParserSamePercentage rawPercentageOf: 5).
+
+	self
+		assert: (testParserSamePercentage rawPercentageOf: 5)
+		equals: (testParserSamePercentage rawPercentageOf: 6)
+]
+
+{ #category : 'tests' }
 PerfTreeParserTest >> testReadLine [
 
 	self

--- a/src/PerfTreeParser/PerfTreeNode.class.st
+++ b/src/PerfTreeParser/PerfTreeNode.class.st
@@ -7,7 +7,8 @@ Class {
 		'parent',
 		'totalTime',
 		'time',
-		'timeWithChildren'
+		'timeWithChildren',
+		'rawPercentage'
 	],
 	#category : 'PerfTreeParser',
 	#package : 'PerfTreeParser'
@@ -88,6 +89,18 @@ PerfTreeNode >> parent: aTreeNode [
 ]
 
 { #category : 'accessing' }
+PerfTreeNode >> rawPercentage [
+
+	^ rawPercentage
+]
+
+{ #category : 'accessing' }
+PerfTreeNode >> rawPercentage: anObject [
+
+	rawPercentage := anObject
+]
+
+{ #category : 'accessing' }
 PerfTreeNode >> time [
 
 	^ time
@@ -134,5 +147,6 @@ PerfTreeNode >> traces [
 		  PerfTreeTrace new
 			  name: l name;
 			  time: l time;
+			  rawPercentage: l rawPercentage;
 			  yourself ]
 ]

--- a/src/PerfTreeParser/PerfTreeParser.class.st
+++ b/src/PerfTreeParser/PerfTreeParser.class.st
@@ -133,6 +133,7 @@ PerfTreeParser >> nodeAtIndex: aNodeIndex [
 		         time: (self timeOf: aNodeIndex);
 		         totalTime: self time;
 					timeWithChildren: (self timeWithChildrenOf: aNodeIndex);
+					rawPercentage: (self rawPercentageOf: aNodeIndex);
 		         yourself.
 	node children: (self findChildrenOfIndex: aNodeIndex).
 	node children do: [ :child | child parent: node ].
@@ -161,23 +162,37 @@ PerfTreeParser >> numberOfSpacesAt: aNodeIndex [
 ]
 
 { #category : 'accessing' }
-PerfTreeParser >> percentageOf: aLine [
+PerfTreeParser >> percentageOf: aLineIndex [
 	"Gives the percentage from a function at a given line"
 
 	"In the case of multiples functions for one percentage, it gives the same percentage to every functions."
 
 	| stringLine numbers |
-	(aLine between: 1 and: self numberOfFunctions) ifFalse: [ ^ 0 ].
+	stringLine := self rawPercentageOf: aLineIndex.
 
-	stringLine := ((((self readLine: aLine) copyUpTo: $%) last: 5)
-		              copyWithout: $-) copyWithout: Character space.
-
-	stringLine = ((self readLine: aLine) last: stringLine size) ifTrue: [
-		^ self percentageOf: aLine - 1 ].
+	stringLine ifEmpty: [ ^ 0 ].
 
 	numbers := stringLine asNumber.
 
 	^ numbers
+]
+
+{ #category : 'accessing' }
+PerfTreeParser >> rawPercentageOf: aLine [
+	"Gives the percentage from a function at a given line"
+
+	"In the case of multiples functions for one percentage, it gives the same percentage to every functions."
+
+	| stringLine |
+	(aLine between: 1 and: self numberOfFunctions) ifFalse: [ ^ '' ].
+
+	stringLine := ((((self readLine: aLine) copyUpTo: $%) last: 5)
+		               copyWithout: $-) copyWithout: Character space.
+
+	stringLine = ((self readLine: aLine) last: stringLine size) ifTrue: [
+		^ self rawPercentageOf: aLine - 1 ].
+
+	^ stringLine
 ]
 
 { #category : 'accessing' }

--- a/src/PerfTreeParser/PerfTreeTrace.class.st
+++ b/src/PerfTreeParser/PerfTreeTrace.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'name',
-		'time'
+		'time',
+		'rawPercentage'
 	],
 	#category : 'PerfTreeParser',
 	#package : 'PerfTreeParser'
@@ -19,6 +20,18 @@ PerfTreeTrace >> name [
 PerfTreeTrace >> name: aName [
 
 	name := aName
+]
+
+{ #category : 'accessing' }
+PerfTreeTrace >> rawPercentage [
+
+	^ rawPercentage
+]
+
+{ #category : 'accessing' }
+PerfTreeTrace >> rawPercentage: anObject [
+
+	rawPercentage := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/PerfTreeParser/PerfTreeTree.class.st
+++ b/src/PerfTreeParser/PerfTreeTree.class.st
@@ -13,7 +13,7 @@ PerfTreeTree >> hardestCall [
 
 	| hardest |
 	traces ifEmpty: [ ^ nil ] ifNotEmpty: [ hardest := traces first ].
-	traces do: [:trace | trace time > hardest time ifTrue: [ hardest := trace ] ].
+	traces do: [:trace | trace rawPercentage asNumber > hardest rawPercentage asNumber ifTrue: [ hardest := trace ] ].
 	^ hardest
 ]
 


### PR DESCRIPTION
Added `rawPercentage` to have the percentages present in the file as strings and keep the precision of it.
Added tests to it.
Now the method `hardestCall` uses this `rawPercentage` to decide which trace took the most time.